### PR TITLE
Feature/auth

### DIFF
--- a/backend/src/main/java/org/scoula/member/dto/MemberResponseDTO.java
+++ b/backend/src/main/java/org/scoula/member/dto/MemberResponseDTO.java
@@ -13,12 +13,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemberResponseDTO {
-    // 민감 정보(password, fcmToken, phoneNumber) 제외
+    // 민감 정보(password, fcmToken) 제외
     private int userId;
     private String email;
     private String nickname;
     private String name;
     private String maskedPhoneNumber;
+    private String phoneNumber;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;

--- a/backend/src/main/java/org/scoula/member/dto/MemberUpdateDTO.java
+++ b/backend/src/main/java/org/scoula/member/dto/MemberUpdateDTO.java
@@ -37,4 +37,11 @@ public class MemberUpdateDTO {
 
     // 업데이트 일시
     private LocalDateTime createdAt;
+
+    // 비밀번호
+    @Size(min = 9, max = 100, message = "비밀번호는 9자 이상이어야 합니다.")
+    private String password;
+
+    private String confirmPassword;
+    private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/org/scoula/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/org/scoula/member/service/MemberServiceImpl.java
@@ -220,14 +220,8 @@ public class MemberServiceImpl implements MemberService {
             // 6. password 업데이트 추가
             if (StringUtils.hasText(updateDTO.getPassword())) {
                 String encodedPassword = passwordEncoder.encode(updateDTO.getPassword());
-                log.info("🔐 새 비밀번호 해시값: {}", encodedPassword);
-
                 memberMapper.updatePassword(userId, encodedPassword, LocalDateTime.now());
-                log.info("회원 비밀번호 수정 완료 - 회원 ID : {}", userId);
-
-                // 🔍 DB 반영 확인용 로그 추가
                 MemberVO afterUpdate = memberMapper.findById(userId);
-                log.info("📦 DB 저장된 해시값: {}", afterUpdate.getPassword());
             }
 
             // 7. 수정된 정보 응답 DTO 생성

--- a/backend/src/main/java/org/scoula/member/service/MemberServiceImpl.java
+++ b/backend/src/main/java/org/scoula/member/service/MemberServiceImpl.java
@@ -172,8 +172,10 @@ public class MemberServiceImpl implements MemberService {
             responseDTO.setEmail(memberVO.getEmail());
             responseDTO.setNickname(memberVO.getNickname());
             responseDTO.setName(memberVO.getName());
+            responseDTO.setPhoneNumber(memberVO.getPhoneNumber());
             responseDTO.setMaskedPhoneNumber(maskPhoneNumber(memberVO.getPhoneNumber()));
             responseDTO.setCreatedAt(memberVO.getCreatedAt());
+            responseDTO.setUpdatedAt(memberVO.getUpdatedAt());
             return responseDTO;
         } catch (UserNotFoundException e) {
             throw e;
@@ -215,7 +217,20 @@ public class MemberServiceImpl implements MemberService {
             memberMapper.updateMember(memberVO);
             log.info("회원 정보 수정 완료 - 회원 ID : {}", userId);
 
-            // 6. 수정된 정보 응답 DTO 생성
+            // 6. password 업데이트 추가
+            if (StringUtils.hasText(updateDTO.getPassword())) {
+                String encodedPassword = passwordEncoder.encode(updateDTO.getPassword());
+                log.info("🔐 새 비밀번호 해시값: {}", encodedPassword);
+
+                memberMapper.updatePassword(userId, encodedPassword, LocalDateTime.now());
+                log.info("회원 비밀번호 수정 완료 - 회원 ID : {}", userId);
+
+                // 🔍 DB 반영 확인용 로그 추가
+                MemberVO afterUpdate = memberMapper.findById(userId);
+                log.info("📦 DB 저장된 해시값: {}", afterUpdate.getPassword());
+            }
+
+            // 7. 수정된 정보 응답 DTO 생성
             MemberResponseDTO responseDTO = new MemberResponseDTO();
             responseDTO.setUserId(memberVO.getUserId());
             responseDTO.setEmail(memberVO.getEmail());

--- a/backend/src/main/java/org/scoula/mypage/controller/MyPageController.java
+++ b/backend/src/main/java/org/scoula/mypage/controller/MyPageController.java
@@ -63,6 +63,10 @@ public class MyPageController {
             Integer userId = customUser.getUserId();
             log.info("회원정보 수정 요청: email={}, userId={}", userEmail, userId);
 
+            if (updateRequest.getPassword() != null && !updateRequest.getPassword().trim().isEmpty()) {
+                log.info("비밀번호 변경도 함께 요청됨");
+            }
+
             boolean result = myPageService.updateUserInfo(userId, updateRequest);
             if (!result) {
                 return ResponseEntity.badRequest().body(ApiResponse.error("회원정보 수정 실패"));
@@ -74,6 +78,7 @@ public class MyPageController {
             return ResponseEntity.badRequest().body(ApiResponse.error("회원정보 수정 중 오류 발생"));
         }
     }
+
 
     // 비밀번호 변경(PUT /api/mypage)
     @PutMapping("/password")

--- a/backend/src/main/java/org/scoula/mypage/dto/UserUpdateRequestDTO.java
+++ b/backend/src/main/java/org/scoula/mypage/dto/UserUpdateRequestDTO.java
@@ -30,5 +30,12 @@ public class UserUpdateRequestDTO {
     @Pattern(regexp = "^01[0-9]-[0-9]{4}-[0-9]{4}$", message = "올바른 휴대폰 번호 형식을 입력해주세요. (예: 010-1234-5678)")
     private String phoneNumber;
 
+    @Size(min = 9, message = "비밀번호는 최소 9자 이상이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{9,}$",
+            message = "비밀번호는 영문 소문자, 숫자, 특수문자를 포함해 9자 이상이어야 합니다."
+    )
+    private String password;
+
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/backend/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -157,6 +157,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         // 기본 인증 방식 비활성화
         http
+                .cors().and()
                 .httpBasic().disable()  // HTTP Basic 인증 비활성화
                 .csrf().disable()  // CSRF 보호 비활성화 (JWT 사용으로 불필요)
                 .formLogin().disable()  // 폼 로그인 비활성화

--- a/backend/src/main/webapp/resources/index.html
+++ b/backend/src/main/webapp/resources/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <link rel="icon" href="/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>✈️N빵트립</title>
-    <script type="module" crossorigin src="/assets/index-f6bP4CTi.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-EUmSybLQ.css" />
+    <script type="module" crossorigin src="/assets/index-BYmn_kqx.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-XitoRsq3.css">
   </head>
   <body>
     <div id="app"></div>

--- a/backend/src/main/webapp/resources/index.html
+++ b/backend/src/main/webapp/resources/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>✈️N빵트립</title>
-    <script type="module" crossorigin src="/assets/index-BYmn_kqx.js"></script>
+    <script type="module" crossorigin src="/assets/index-CSwC09pL.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-XitoRsq3.css">
   </head>
   <body>

--- a/frontend/src/api/memberApi.js
+++ b/frontend/src/api/memberApi.js
@@ -116,43 +116,16 @@ export const updateMyInfo = async (memberData) => {
             email: memberData.email
         };
 
-        // 수정사항: 비밀번호 처리 전후 로깅
-        console.log('전송 전 memberData.password:', memberData.password);
-        console.log('비밀번호 길이:', memberData.password?.length);
-        console.log('비밀번호 trim 후:', memberData.password?.trim());
-
         if (memberData.password && memberData.password.trim() !== '') {
             requestData.password = memberData.password;
-            console.log('✅ 비밀번호가 requestData에 포함됨');
+            console.log('비밀번호가 requestData에 포함됨');
         } else {
-            console.log('❌ 비밀번호가 requestData에 포함되지 않음');
+            console.log('비밀번호가 requestData에 포함되지 않음');
         }
-
-        // 수정사항: 실제 전송되는 데이터의 전체 구조 확인
-        console.log('🚀 실제 서버로 전송되는 데이터:');
-        console.log('- 키 목록:', Object.keys(requestData));
-        console.log('- password 필드 존재:', 'password' in requestData);
-        console.log('- 전체 구조:', JSON.stringify(requestData, (key, value) => {
-            if (key === 'password') return '***';
-            return value;
-        }));
-
         const response = await apiClient.put('/mypage', requestData);
-
-        // 수정사항: 서버 응답 상세 로깅
-        console.log('📥 서버 응답:');
-        console.log('- 상태 코드:', response.status);
-        console.log('- 응답 데이터:', response.data);
-
         return response.data;
     } catch (error) {
-        // 수정사항: 에러 상세 로깅
-        console.error('🚨 API 에러 상세:');
-        console.error('- 에러 메시지:', error.message);
-        console.error('- 응답 상태:', error.response?.status);
-        console.error('- 응답 데이터:', error.response?.data);
-        console.error('- 요청 설정:', error.config);
-
+        console.error('API 에러:', error.message);
         throw handleApiError(error, '회원정보 수정');
     }
 };

--- a/frontend/src/api/memberApi.js
+++ b/frontend/src/api/memberApi.js
@@ -106,21 +106,57 @@ export const verifyPassword = async (password) => {
 };
 
 // 회원정보 수정
+// 회원정보 수정 함수 - 상세 디버깅 추가
 export const updateMyInfo = async (memberData) => {
     try {
-        const response = await apiClient.put('/mypage', {
+        const requestData = {
             nickname: memberData.nickname,
             name: memberData.name,
             phoneNumber: memberData.phoneNumber,
-            email: memberData.email,
-            password: memberData.password,
-            passwordConfirm : memberData.passwordConfirm
-        });
+            email: memberData.email
+        };
+
+        // 수정사항: 비밀번호 처리 전후 로깅
+        console.log('전송 전 memberData.password:', memberData.password);
+        console.log('비밀번호 길이:', memberData.password?.length);
+        console.log('비밀번호 trim 후:', memberData.password?.trim());
+
+        if (memberData.password && memberData.password.trim() !== '') {
+            requestData.password = memberData.password;
+            console.log('✅ 비밀번호가 requestData에 포함됨');
+        } else {
+            console.log('❌ 비밀번호가 requestData에 포함되지 않음');
+        }
+
+        // 수정사항: 실제 전송되는 데이터의 전체 구조 확인
+        console.log('🚀 실제 서버로 전송되는 데이터:');
+        console.log('- 키 목록:', Object.keys(requestData));
+        console.log('- password 필드 존재:', 'password' in requestData);
+        console.log('- 전체 구조:', JSON.stringify(requestData, (key, value) => {
+            if (key === 'password') return '***';
+            return value;
+        }));
+
+        const response = await apiClient.put('/mypage', requestData);
+
+        // 수정사항: 서버 응답 상세 로깅
+        console.log('📥 서버 응답:');
+        console.log('- 상태 코드:', response.status);
+        console.log('- 응답 데이터:', response.data);
+
         return response.data;
     } catch (error) {
+        // 수정사항: 에러 상세 로깅
+        console.error('🚨 API 에러 상세:');
+        console.error('- 에러 메시지:', error.message);
+        console.error('- 응답 상태:', error.response?.status);
+        console.error('- 응답 데이터:', error.response?.data);
+        console.error('- 요청 설정:', error.config);
+
         throw handleApiError(error, '회원정보 수정');
     }
 };
+
 
 // ====== 유틸리티 함수 ======
 // API 에러 처리 함수

--- a/frontend/src/views/member/mypage/MyInfoPasswordPage.vue
+++ b/frontend/src/views/member/mypage/MyInfoPasswordPage.vue
@@ -19,8 +19,14 @@ const goBack = () => {
 
 // 완료 버튼 클릭 시 실행되는 비밀번호 검증 함수
 const handleVerifyPassword = async () => {
+  errorMessage.value = '';
+  const trimmedPassword = password.value.trim();
+  if (!password.value || password.value.trim().length === 0) {
+    errorMessage.value = '비밀번호를 입력해주세요.';
+    return;
+  }
   try {
-    const response = await verifyPassword(password.value)
+    const response = await verifyPassword(trimmedPassword);
 
     // 비밀번호 검증 성공 시 /mypage/updateInfo 페이지로 이동
     if (response.success) {
@@ -51,10 +57,10 @@ const handleVerifyPassword = async () => {
       <!-- 비밀번호 입력 필드 -->
       <input
           type="password"
-          v-model="password"
+          v-model.trim="password"
           placeholder="비밀번호 입력"
           class="password-input"
-          @keyup.enter="verifyPassword"
+          @keyup.enter.prevent="handleVerifyPassword"
       />
 
       <!-- 에러 메시지 출력 -->

--- a/frontend/src/views/member/mypage/MyInfoUpdatePage.vue
+++ b/frontend/src/views/member/mypage/MyInfoUpdatePage.vue
@@ -9,11 +9,16 @@ const router = useRouter()
 
 // 사용자 정보 상태
 const nickname = ref('');
+const originalNickname = ref('');
 const name = ref('');
 const phoneNumber = ref('');
+const maskedPhoneNumber = ref('');
 const email = ref('');
 const password = ref('');
 const passwordConfirm = ref('');
+
+// 비밀번호 변경 여부 추적 상태
+const isPasswordChanged = ref(false);
 
 // 닉네임 중복 확인 상태
 const isNicknameChecked = ref(false);
@@ -38,6 +43,24 @@ const checkNickname = async () => {
   }
 };
 
+// 닉네임 변경 시 중복 확인 상태 초기화
+watch (nicknameValid, (newVal, oldVal) => {
+  if (newVal !== originalNickname.value) {
+    isNicknameChecked.value = false;
+    nicknameValid.value = false;
+    nicknameMessage.value = '';
+  } else {
+    isNicknameChecked.value = true;
+    nicknameValid.value = true;
+    nicknameMessage.value = '';
+  }
+});
+
+// 비밀번호 변경 여부 추적
+watch([password, passwordConfirm], () => {
+  isPasswordChanged.value = password.value.length > 0 || passwordConfirm.value.length > 0;
+});
+
 // 이름 유효성 검사
 const isNameValid = computed(() => name.value.length >= 2);
 const nameMessage = computed(() =>
@@ -59,9 +82,13 @@ watch(email, () => {
 const passwordMessage = ref('');
 const isPasswordValid = computed(() => /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{9,}$/.test(password.value));
 watch(password, () => {
-  passwordMessage.value = isPasswordValid.value
-      ? '사용 가능한 비밀번호입니다.'
-      : '영문, 숫자, 특수문자를 포함해 9자 이상이어야 합니다.';
+  if (password.value) {
+    passwordMessage.value = isPasswordValid.value
+        ? '사용 가능한 비밀번호입니다.'
+        : '영문, 숫자, 특수문자를 포함해 9자 이상이어야 합니다.';
+  } else {
+    passwordMessage.value = '';
+  }
 });
 
 // 비밀번호 일치 여부
@@ -87,13 +114,14 @@ onMounted(async () => {
   try {
     const res = await getMyInfo()
     if (res.success) {
-      nickname.value = res.data.nickname
-      name.value = res.data.name
-      phoneNumber.value = res.data.phoneNumber
-      email.value = res.data.email
-      phoneNumber.value = res.data.phoneNumber
-      password.value = res.data.password
-      passwordConfirm.value = res.data.passwordConfirm
+      nickname.value = res.data.nickname;
+      originalNickname.value = res.data.nickname;
+      name.value = res.data.name;
+      maskedPhoneNumber.value = res.data.maskedPhoneNumber;
+      phoneNumber.value = res.data.phoneNumber;
+      email.value = res.data.email;
+      password.value = '';
+      passwordConfirm.value = '';
     }
   } catch (err) {
     alert('회원 정보 조회 실패')
@@ -106,42 +134,66 @@ const submitUpdate = async () => {
       !nickname.value ||
       !name.value ||
       !phoneNumber.value ||
-      !email.value ||
-      !password.value ||
-      !passwordConfirm.value
+      !email.value
   ) {
     alert('모든 항목을 입력해주세요.');
     return;
   }
-  if (!isNicknameChecked.value || !nicknameValid.value) {
-    alert('닉네임 중복 확인을 해주세요.');
-    return;
+
+// 닉네임을 수정했을 경우에만 중복 확인 요구
+  if (nickname.value !== originalNickname.value) {
+    if (!isNicknameChecked.value || !nicknameValid.value) {
+      alert('닉네임 중복 확인을 해주세요.');
+      return;
+    }
   }
-  if (!isPasswordMatch.value || !isPasswordValid.value) {
-    alert('비밀번호를 다시 확인해주세요.');
-    return;
+
+  // 비밀번호 변경 시에만 비밀번호 검증
+  if (isPasswordChanged.value) {
+    if (!password.value || !passwordConfirm.value) {
+      alert('비밀번호와 비밀번호 확인을 모두 입력해주세요.');
+      return;
+    }
+    if (!isPasswordMatch.value || !isPasswordValid.value) {
+      alert('비밀번호를 다시 확인해주세요.');
+      return;
+    }
   }
+
   if (!isPhoneValid.value) {
     alert('전화번호 형식을 확인해주세요.');
     return;
   }
-  try {
-    const res = await updateMyInfo({
-      nickname: nickname.value,
-      name: name.value,
-      phoneNumber: phoneNumber.value,
-      email: email.value,
-      password: password.value,
-      passwordConfirm: passwordConfirm.value
-    })
-    if (res.success) {
-      alert('회원 정보가 수정되었습니다.')
-      router.push('/mypage')  // 수정 완료 후 마이페이지로 이동
+    try {
+      const updateData = {
+        nickname: nickname.value,
+        name: name.value,
+        phoneNumber: phoneNumber.value,
+        email: email.value
+      };
+
+      const isChangingPassword = isPasswordChanged.value && password.value.trim();
+
+      if (isChangingPassword) {
+        updateData.password = password.value;
+      }
+
+      const res = await updateMyInfo(updateData);
+
+      if (res.success) {
+        if (isChangingPassword) {
+          alert('비밀번호가 변경되었습니다.');
+        } else {
+          alert('회원 정보가 수정되었습니다.');
+        }
+        router.push('/mypage');
+      }
+    } catch (err) {
+      console.error('회원정보 수정 오류:', err);
+      alert(err.message || '회원 정보 수정 실패');
     }
-  } catch (err) {
-    alert(err.message || '회원 정보 수정 실패')
-  }
-};
+  };
+
 </script>
 
 <template>
@@ -173,7 +225,8 @@ const submitUpdate = async () => {
 
       <!-- 전화번호 -->
       <label class="label">전화번호</label>
-      <input v-model="phoneNumber" type="text" class="input-box" />
+      <!-- 전화번호 없을 경우에만 마스킹된 번호 placeholder에서 보여주기 -->
+      <input v-model="phoneNumber" type="text" class="input-box" :placeholder="phoneNumber ? '' : maskedPhoneNumber"/>
       <div class="check">
         <span v-if="phoneMessage" :class="isPhoneValid ? 'success' : 'error'">
           {{ phoneMessage }}
@@ -192,6 +245,11 @@ const submitUpdate = async () => {
       <!-- 비밀번호 -->
       <label class="label">비밀번호</label>
       <input v-model="password" type="password" class="input-box" />
+      <div class="check">
+        <span v-if="passwordMessage" :class="isPasswordValid ? 'success' : 'error'">
+          {{ passwordMessage }}
+        </span>
+      </div>
       <p class="password-rules">
         • 비밀번호는 영문 소문자, 숫자를 포함해 최소 9자리 이상이어야 합니다.<br />
         • 3자 이상의 연속되는 글자, 숫자는 사용이 불가능합니다.

--- a/frontend/src/views/member/mypage/MyInfoUpdatePage.vue
+++ b/frontend/src/views/member/mypage/MyInfoUpdatePage.vue
@@ -213,15 +213,9 @@ const submitUpdate = async () => {
           }}</span>
       </div>
 
-      <!-- 이름 -->
+      <!-- 이름(수정 불가) -->
       <label class="label">이름</label>
-      <input v-model="name" type="text" class="input-box" />
-      <div class="check">
-        <span v-if="nameMessage" :class="isNameValid ? 'success' : 'error'">
-          {{ nameMessage }}
-        </span>
-      </div>
-
+      <input v-model="name" type="text" class="input-box readonly-input" readonly />
 
       <!-- 전화번호 -->
       <label class="label">전화번호</label>
@@ -305,6 +299,13 @@ const submitUpdate = async () => {
   padding: 0 12px;
   margin-top: 4px;
   box-sizing: border-box;
+}
+
+.readonly-input {
+  background: #f5f5f5 !important;
+  color: #666;
+  cursor: not-allowed;
+  border-color: #d1d5db;
 }
 
 .nickname-wrapper {

--- a/frontend/src/views/member/mypage/MyPaymentUpdatePage.vue
+++ b/frontend/src/views/member/mypage/MyPaymentUpdatePage.vue
@@ -77,12 +77,6 @@ const loadAccountInfo = async () => {
   }
 }
 
-// 은행명 조회 헬퍼 함수 (표시용)
-const getBankName = (code) => {
-  const bank = bankList.value.find(b => b.bankCode === code)
-  return bank?.bankName || ''
-}
-
 // 저장 버튼 클릭
 const saveAccount = async () => {
   if (!bankCode.value || !accountNumber.value) {
@@ -99,17 +93,20 @@ const saveAccount = async () => {
       return
     }
 
+    // 은행명 조회 헬퍼 함수 (표시용)
+    const bank = bankList.value.find(b => b.bankCode === bankCode.value)
+    const bankNameValue = bank?.bankName || ''
+
     const accountUpdateDTO = {
       bankCode: bankCode.value,
       accountNumber: accountNumber.value,
-      accountAlias: null // 별명은 null로 설정
+      bankName: bankNameValue
     }
 
     await accountApi.updateAccount(userId.value, accountUpdateDTO)
     console.log('계좌 정보 업데이트 성공')
-
-    successMessage.value = '계좌 정보가 저장되었습니다.'
-    errorMessage.value = ''
+    alert('계좌 정보가 저장되었습니다.')
+    router.push('/mypage')
   } catch (err) {
     console.error('계좌 정보 업데이트 실패:', err)
     errorMessage.value = err.message || '저장에 실패했습니다.'
@@ -138,10 +135,12 @@ const saveAccount = async () => {
           placeholder="계좌 번호 입력"
       />
 
-      <Button label="저장하기" @click="saveAccount" />
+      <div class="message-box">
+        <div v-if="successMessage" class="success-message">{{ successMessage }}</div>
+        <div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
+      </div>
 
-      <div v-if="successMessage" class="success-message">{{ successMessage }}</div>
-      <div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
+      <Button label="저장하기" @click="saveAccount" />
     </div>
   </div>
 </template>
@@ -159,7 +158,7 @@ const saveAccount = async () => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding-top: calc(56px + 24px); /* Header 높이만큼 여백 */
+  padding-top: calc(56px + 24px);
   padding-left: 24px;
   padding-right: 24px;
 }
@@ -178,6 +177,12 @@ const saveAccount = async () => {
   padding: 0 16px;
   font-size: 16px;
   background-color: white;
+}
+
+.message-box {
+  margin-top: 16px;  /* 입력란과 간격 */
+  margin-bottom: 16px;  /* 버튼과 간격 */
+  text-align: center;
 }
 
 .success-message {

--- a/frontend/src/views/notification/NotificationList.vue
+++ b/frontend/src/views/notification/NotificationList.vue
@@ -27,10 +27,13 @@ const goToPage = (n) => {
       }
       break;
     case 'SETTLEMENT':
+      router.push(`/settlement/${n.tripId}/detail`);
+      break;
     case 'COMPLETED':
+      router.push(`/settlement/${n.tripId}/completed`);
+      break;
     case 'REMINDER':
-      // 정산 요청 페이지
-      router.push(`/settlement/${n.tripId}`);
+      router.push(`/settlement/${n.tripId}/detail`);
       break;
     case 'INVITE':
       if (!n.memberStatus) {
@@ -79,9 +82,9 @@ const formatAmount = (value) => {
 
 onMounted(() => {
   notificationStore.getNotifications()
-  .then(() => {
-      console.log('notifications:', notifications.value);
-    })
+      .then(() => {
+        console.log('notifications:', notifications.value);
+      })
 });
 
 const getMessage = (n) => {
@@ -92,15 +95,15 @@ const getMessage = (n) => {
     case 'TRANSACTION':
       const isUpdate = n.actionType === 'UPDATE';
       return isUpdate
-        ? `${user}님이 '${place}'결제 내역을 수정했습니다.`
-        : `${user}님이 '${place}'에서 \n${formatAmount(n.amount)}원을 결제했습니다.`; 
+          ? `${user}님이 '${place}'결제 내역을 수정했습니다.`
+          : `${user}님이 '${place}'에서 \n${formatAmount(n.amount)}원을 결제했습니다.`;
 
     case 'SETTLEMENT':
       return `${user}님이 정산 요청을 보냈습니다.\n정산을 확인하시겠습니까?`;
 
     case 'INVITE':
-        return `${user}님이 "${n.tripName}" 그룹에 초대하셨습니다.\n여행에 참여하시겠습니까?`;
-    
+      return `${user}님이 "${n.tripName}" 그룹에 초대하셨습니다.\n여행에 참여하시겠습니까?`;
+
     case 'GROUP_EVENT':
       if (n.memberStatus === 'JOINED') {
         return `${user}님이 "${n.tripName}" 그룹에 참여했어요.`;
@@ -127,7 +130,7 @@ const getMessage = (n) => {
   <div class="notification-content">
     <div class="header-section">
       <Header title="알림" :backAction="goBack"/>
-      
+
       <div class="dropdown-wrapper">
         <button class="dropdown-toggle" @click="toggleDropdown">
           {{ selectedLabel }}
@@ -135,7 +138,7 @@ const getMessage = (n) => {
         </button>
         <ul v-if="showDropdown" class="dropdown-list">
           <li v-for="tab in tabs" :key="tab.value" @click="selectCategory(tab)">
-           {{ tab.label }}
+            {{ tab.label }}
           </li>
         </ul>
       </div>
@@ -162,9 +165,9 @@ const getMessage = (n) => {
       </main>
     </div>
   </div>
-  
-      
-   
+
+
+
 </template>
 
 <style scoped>
@@ -227,8 +230,8 @@ const getMessage = (n) => {
 .dropdown-divider {
   width: 100%;
   height: 1px;
-  background-color: #babec4; 
-  margin-top: -60px; 
+  background-color: #babec4;
+  margin-top: -60px;
 }
 
 .icon{
@@ -248,7 +251,7 @@ const getMessage = (n) => {
   padding: 14px 14px;
   margin-right: 1%;
   margin-left: 1%;
-  
+
   border-bottom: 1px solid #e5e7eb; /* 리스트 느낌 */
   display: flex;
   justify-content: space-between;
@@ -292,4 +295,3 @@ const getMessage = (n) => {
   color: gray;
 }
 </style>
-


### PR DESCRIPTION
강사님 피드백 반영하여 회원정보 수정 기능 개선 완료했습니다.

- 휴대폰 번호 표시 : 마스킹 없이 정상 출력되도록 수정
- 이름 : 수정 불가능하도록 수정
- 비밀번호 입력(구현 ❌) : 암호화 저장으로 인해 비밀번호는 화면에 표시될 수 없음
 → 비밀번호, 비밀번호 확인 칸 비워둔 채(회원정보 수정 클릭하면 나오는 디폴트 값 그대로) 저장하면 기존 비밀번호 유지되도록 처리
- 닉네임 중복 확인 버튼 : 닉네임 수정 시에만 동작하도록 개선
- 결제 수단 에러 : 오류 수정